### PR TITLE
kaizen - reorder stacks numerically

### DIFF
--- a/functions/deleteLastStack/handler.ts
+++ b/functions/deleteLastStack/handler.ts
@@ -1,7 +1,8 @@
+import { Project } from '@libs/entities/project';
 import { Stack } from '@libs/entities/stack';
 import { applyHttpMiddleware } from '@libs/middlewares';
 import type { CustomAPIGatewayProxyHandler } from '@libs/utils';
-import { success } from '@libs/utils';
+import { sortStacks, success } from '@libs/utils';
 import { projectKeyAuthorizer } from '@libs/utils/http/projectKeyAuthorizer';
 
 import { releaseStackInputSchema } from './input.schema';
@@ -12,10 +13,13 @@ const deleteLastStack: CustomAPIGatewayProxyHandler<
 > = async ({ headers: { 'x-api-key': projectKey } }) => {
   await projectKeyAuthorizer(projectKey);
   const { Items: stacks } = await Stack.query(Stack.name, { beginsWith: projectKey });
+  const { Item: project } = await Project.get({ projectKey });
+
   if (stacks === undefined || stacks.length === 0) {
     return success({ message: `No more stack` });
   }
-  const lastStack = stacks[stacks.length - 1];
+  const sortedStacks = sortStacks(stacks, project?.prefix);
+  const lastStack = sortedStacks[sortedStacks.length - 1];
   const { stackName } = lastStack;
   await Stack.delete({ projectKey, stackName });
 

--- a/functions/listStacks/handler.ts
+++ b/functions/listStacks/handler.ts
@@ -1,10 +1,11 @@
 import omit from 'lodash/omit';
 
 import { listStacksInputSchema } from '@functions/listStacks/input.schema';
+import { Project } from '@libs/entities/project';
 import { Stack } from '@libs/entities/stack';
 import { applyHttpMiddleware } from '@libs/middlewares';
 import type { CustomAPIGatewayProxyHandler } from '@libs/utils';
-import { success, throwIfNil } from '@libs/utils';
+import { sortStacks, success, throwIfNil } from '@libs/utils';
 import { projectKeyAuthorizer } from '@libs/utils/http/projectKeyAuthorizer';
 
 const listStacks: CustomAPIGatewayProxyHandler<typeof listStacksInputSchema, unknown> = async ({
@@ -13,10 +14,14 @@ const listStacks: CustomAPIGatewayProxyHandler<typeof listStacksInputSchema, unk
   await projectKeyAuthorizer(projectKey);
 
   const { Items: stacks } = await Stack.query(Stack.name, { beginsWith: projectKey });
+  const { Item: project } = await Project.get({ projectKey });
 
   throwIfNil(stacks, 'stacks must exist');
+  const sortedStacks = sortStacks(stacks, project?.prefix);
 
-  return success({ stacks: stacks.map(stack => omit(stack, 'projectKey')) });
+  return success({
+    stacks: sortedStacks.map(stack => omit(stack, 'projectKey')),
+  });
 };
 
 export const main = applyHttpMiddleware(listStacks, { inputSchema: listStacksInputSchema });

--- a/functions/requestStack/handler.ts
+++ b/functions/requestStack/handler.ts
@@ -4,7 +4,7 @@ import { Project } from '@libs/entities/project';
 import { Stack } from '@libs/entities/stack';
 import { applyHttpMiddleware } from '@libs/middlewares';
 import type { CustomAPIGatewayProxyHandler } from '@libs/utils';
-import { success, throwIfNil } from '@libs/utils';
+import { DEFAULT_STACK_PREFIX, success, throwIfNil } from '@libs/utils';
 import { projectKeyAuthorizer } from '@libs/utils/http/projectKeyAuthorizer';
 
 const defaultBranch = 'main';
@@ -20,7 +20,7 @@ const requestStack: CustomAPIGatewayProxyHandler<typeof requestStackInputSchema,
   throwIfNil(stacks, 'stacks must exist');
   throwIfNil(project);
 
-  const { initialCommit, prefix = 'test-' } = project;
+  const { initialCommit, prefix = DEFAULT_STACK_PREFIX } = project;
 
   const availableStack = getAvailableStack(stacks, branch);
 

--- a/libs/utils/constants.ts
+++ b/libs/utils/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_STACK_PREFIX = 'test-';

--- a/libs/utils/index.ts
+++ b/libs/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './http';
 export * from './env';
 export * from './enums';
+export * from './sortStacks';
 export * from './isLocalLambdaInvocation';
 export * from './typeGuards';
 export * from './constants';

--- a/libs/utils/index.ts
+++ b/libs/utils/index.ts
@@ -3,3 +3,4 @@ export * from './env';
 export * from './enums';
 export * from './isLocalLambdaInvocation';
 export * from './typeGuards';
+export * from './constants';

--- a/libs/utils/sortStacks.test.ts
+++ b/libs/utils/sortStacks.test.ts
@@ -1,0 +1,54 @@
+import { stackFixtureFactory } from '@libs/entities/stack.fixture';
+
+import { DEFAULT_STACK_PREFIX } from './constants';
+import { getStackNumber, sortStacks } from './sortStacks';
+
+const project = { prefix: 'test-N-' };
+
+const unsortedStacks = [
+  stackFixtureFactory({ stackName: 'test-N-10' }),
+  stackFixtureFactory({ stackName: 'test-N-1' }),
+  stackFixtureFactory({ stackName: 'test-N-9' }),
+];
+
+const sortedStacks = [
+  stackFixtureFactory({ stackName: 'test-N-1' }),
+  stackFixtureFactory({ stackName: 'test-N-9' }),
+  stackFixtureFactory({ stackName: 'test-N-10' }),
+];
+
+const unsortedStacksWithoutPrefix = [
+  stackFixtureFactory({ stackName: 'test-10' }),
+  stackFixtureFactory({ stackName: 'test-1' }),
+  stackFixtureFactory({ stackName: 'test-9' }),
+];
+
+const sortedStacksWithoutPrefix = [
+  stackFixtureFactory({ stackName: 'test-1' }),
+  stackFixtureFactory({ stackName: 'test-9' }),
+  stackFixtureFactory({ stackName: 'test-10' }),
+];
+
+describe('getStackNumber', () => {
+  it('should return the stack number when the project has a prefix', () => {
+    const stackNumber = getStackNumber(unsortedStacks[0], project.prefix);
+    expect(stackNumber).toEqual(10);
+  });
+
+  it('should return the stack number when the project does not have a prefix', () => {
+    const stackNumber = getStackNumber(unsortedStacksWithoutPrefix[0], DEFAULT_STACK_PREFIX);
+    expect(stackNumber).toEqual(10);
+  });
+});
+
+describe('sortStacks', () => {
+  it('should sort stacks numerically when the project has a prefix', () => {
+    const stacks = sortStacks(unsortedStacks, project.prefix);
+    expect(stacks).toEqual(sortedStacks);
+  });
+
+  it('should sort stacks alphabetically when the project does not have a prefix', () => {
+    const stacks = sortStacks(unsortedStacksWithoutPrefix, DEFAULT_STACK_PREFIX);
+    expect(stacks).toEqual(sortedStacksWithoutPrefix);
+  });
+});

--- a/libs/utils/sortStacks.ts
+++ b/libs/utils/sortStacks.ts
@@ -1,0 +1,17 @@
+import type { StackEntity } from '@libs/entities/stack';
+
+import { DEFAULT_STACK_PREFIX } from './constants';
+
+export const getStackNumber = (stack: StackEntity, prefix: string): number =>
+  Number(stack.stackName.split(prefix)[1]);
+
+export const sortStacks = (
+  stacks: StackEntity[],
+  projectPrefix: string | undefined,
+): StackEntity[] => {
+  const prefix = projectPrefix !== undefined ? projectPrefix : DEFAULT_STACK_PREFIX;
+
+  return stacks.sort(
+    (stackA, stackB) => getStackNumber(stackA, prefix) - getStackNumber(stackB, prefix),
+  );
+};


### PR DESCRIPTION
_why?_
when deleting the last stack, we were getting the stacks sorted by alphabetical order (ex: test-1, test-10, test-2, test-3, ..., test-9) so we would delete test-9 instead of test-9

_what?_
reorder stacks in numerical order > test-1, test-2, ..., test-9, test-10